### PR TITLE
Add MseeP.ai badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![MseeP.ai Security Assessment Badge](https://mseep.net/pr/hideya-langchain-mcp-tools-py-usage-badge.png)](https://mseep.ai/app/hideya-langchain-mcp-tools-py-usage)
+
 # MCP Tools Usage From LangChain / Example in Python [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/hideya/langchain-mcp-tools-py-usage/blob/main/LICENSE)
 
 This simple [Model Context Protocol (MCP)](https://modelcontextprotocol.io/)


### PR DESCRIPTION
Hi there,

This pull request shares a security update on langchain-mcp-tools-py-usage.

We also have an entry for langchain-mcp-tools-py-usage in our directory, MseeP.ai, where we provide regular security and trust updates on your app.

We invite you to add our badge for your MCP server to your README to help your users learn from a third party that provides ongoing validation of langchain-mcp-tools-py-usage.

You can easily take control over your listing for free: visit it at https://mseep.ai/app/hideya-langchain-mcp-tools-py-usage.

Yours Sincerely,

Lawrence W. Sinclair
CEO/SkyDeck AI
Founder of MseeP.ai
*MCP servers you can trust*

---

[![MseeP.ai Security Assessment Badge](https://mseep.net/pr/hideya-langchain-mcp-tools-py-usage-badge.png)](https://mseep.ai/app/hideya-langchain-mcp-tools-py-usage)


Here are our latest evaluation results of langchain-mcp-tools-py-usage

## Security Scan Results

**Security Score:** 90/100

**Risk Level:** low

**Scan Date:** 2025-05-08


Score starts at 100, deducts points for security issues, and adds points for security best practices


### Security Findings


#### Medium Severity Issues

* **semgrep**: Hardcoded JWT secret or private key is used. This is a Insufficiently Protected Credentials weakness: https://cwe.mitre.org/data/definitions/522.html Consider using an appropriate security mechanism to protect the credentials (e.g. keeping secrets in environment variables)
  - Location: src/sse-auth-test-client.py
  - Line: 59

* **semgrep**: Hardcoded JWT secret or private key is used. This is a Insufficiently Protected Credentials weakness: https://cwe.mitre.org/data/definitions/522.html Consider using an appropriate security mechanism to protect the credentials (e.g. keeping secrets in environment variables)
  - Location: src/sse-auth-test-server.py
  - Line: 46


This security assessment was conducted by MseeP.ai, an independent security validation service for MCP servers. Visit our [website](https://mseep.ai) to learn more about our security reviews.

